### PR TITLE
feat(sentimental_analyzer): add Vader & CamemBERT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "seaborn>=0.13.0",
     "rich>=14.3.3",
     "spacy>=3.8.13",
+    "vaderSentiment>=3.3.2",
+    "transformers>=4.40.0",
 ]
 
 [project.scripts]

--- a/tests/test_sentiment_analyzer.py
+++ b/tests/test_sentiment_analyzer.py
@@ -13,10 +13,6 @@ import pytest
 from whatsapp_analyzer.sentiment_analyzer import SentimentAnalyzer
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 def _make_df(messages: list[str], authors: list[str] | None = None) -> pd.DataFrame:
     """Return a minimal cleaned DataFrame that mimics Cleaner output."""
     n = len(messages)
@@ -37,17 +33,17 @@ def _make_df(messages: list[str], authors: list[str] | None = None) -> pd.DataFr
 
 
 _TEXTS = [
-    "super excellent fantastique",   # strongly positive
-    "terrible horrible mauvais",     # strongly negative
-    "bonjour au revoir",             # neutral
-    "génial bravo merveilleux",      # positive
-    "nul catastrophe désastre",      # negative
-    "cours demain annulé",           # neutral-ish
+    "super excellent fantastique",   
+    "terrible horrible mauvais",     
+    "bonjour au revoir",            
+    "génial bravo merveilleux",      
+    "nul catastrophe désastre",      
+    "cours demain annulé",          
 ]
 _AUTHORS = ["Aminata", "Moussa", "Aminata", "Moussa", "Aminata", "Moussa"]
 
 
-# Patch target for VADER inside the module
+"Patch target for VADER inside the module"
 _VADER_CLS = "vaderSentiment.vaderSentiment.SentimentIntensityAnalyzer"
 
 
@@ -62,9 +58,6 @@ def _make_vader_mock(scores: list[float] | None = None):
     return mock_vader
 
 
-# ---------------------------------------------------------------------------
-# Return type and structure
-# ---------------------------------------------------------------------------
 
 def test_analyze_returns_dict():
     df = _make_df(_TEXTS, _AUTHORS)
@@ -94,9 +87,6 @@ def test_analyze_has_global_key():
     assert "global" in result
 
 
-# ---------------------------------------------------------------------------
-# Output DataFrame columns and types
-# ---------------------------------------------------------------------------
 
 def test_output_df_has_sentiment_score_column():
     df = _make_df(_TEXTS, _AUTHORS)
@@ -152,9 +142,6 @@ def test_input_dataframe_not_mutated():
     assert set(df.columns) == original_cols
 
 
-# ---------------------------------------------------------------------------
-# Label thresholds
-# ---------------------------------------------------------------------------
 
 def test_positive_label_above_threshold():
     df = _make_df(["good"], ["Aminata"])
@@ -196,10 +183,6 @@ def test_boundary_negative_threshold_is_inclusive():
     assert result["df"]["sentiment_label"].iloc[0] == "negative"
 
 
-# ---------------------------------------------------------------------------
-# by_user DataFrame
-# ---------------------------------------------------------------------------
-
 def test_by_user_is_dataframe():
     df = _make_df(_TEXTS, _AUTHORS)
     with patch(_VADER_CLS, return_value=_make_vader_mock()):
@@ -228,10 +211,6 @@ def test_by_user_row_count_matches_unique_authors():
     n_authors = df["author"].nunique()
     assert len(result["by_user"]) == n_authors
 
-
-# ---------------------------------------------------------------------------
-# global stats dict
-# ---------------------------------------------------------------------------
 
 def test_global_has_mean_key():
     df = _make_df(_TEXTS, _AUTHORS)
@@ -311,10 +290,6 @@ def test_global_neg_pct_correctness():
     assert abs(result["global"]["neg_pct"] - 2 / 6) < 1e-6
 
 
-# ---------------------------------------------------------------------------
-# VADER wiring
-# ---------------------------------------------------------------------------
-
 def test_vader_polarity_scores_called_for_each_message():
     df = _make_df(_TEXTS, _AUTHORS)
     mock_vader = _make_vader_mock()
@@ -334,10 +309,6 @@ def test_vader_compound_key_is_used():
     assert result["df"]["sentiment_score"].iloc[0] == pytest.approx(0.5)
 
 
-# ---------------------------------------------------------------------------
-# Error cases
-# ---------------------------------------------------------------------------
-
 def test_empty_dataframe_raises_value_error():
     df = pd.DataFrame(columns=["cleaned_message", "author"])
     with pytest.raises(ValueError, match="empty"):
@@ -356,10 +327,10 @@ def test_missing_author_column_raises():
         SentimentAnalyzer().analyze(df)
 
 
-# ---------------------------------------------------------------------------
-# CamemBERT path (issue #06)
-# transformers is never imported for real — the whole module is mocked.
-# ---------------------------------------------------------------------------
+"""
+CamemBERT path (issue #06)
+transformers is never imported for real — the whole module is mocked.
+"""
 
 def _make_camembert_pipeline_mock(
     labels_scores: list[tuple[str, float]] | None = None
@@ -392,7 +363,7 @@ def _make_transformers_module_mock(pipeline_instance):
     return mod
 
 
-# --- return type and structure ---
+""" --- return type and structure --- """
 
 def test_camembert_analyze_returns_dict():
     df = _make_df(_TEXTS, _AUTHORS)
@@ -434,7 +405,7 @@ def test_camembert_preserves_row_count():
     assert len(result["df"]) == len(df)
 
 
-# --- positive label maps to +score ---
+""" --- positive label maps to +score --- """
 
 def test_camembert_label1_gives_positive_score():
     df = _make_df(["super"], ["Aminata"])
@@ -462,7 +433,7 @@ def test_camembert_label_values_are_valid():
     )
 
 
-# --- fallback to VADER when transformers is absent ---
+""" --- fallback to VADER when transformers is absent --- """
 
 def test_camembert_falls_back_to_vader_when_not_installed():
     df = _make_df(_TEXTS, _AUTHORS)
@@ -475,7 +446,7 @@ def test_camembert_falls_back_to_vader_when_not_installed():
     assert mock_vader.polarity_scores.call_count == len(_TEXTS)
 
 
-# --- non-French language routes to VADER even when transformers is present ---
+""" --- non-French language routes to VADER even when transformers is present --- """
 
 def test_english_lang_uses_vader_not_camembert():
     df = _make_df(_TEXTS, _AUTHORS)
@@ -488,12 +459,12 @@ def test_english_lang_uses_vader_not_camembert():
     assert pipe.call_count == 0
 
 
-# --- VADER path unaffected after CamemBERT addition ---
+ """--- VADER path unaffected after CamemBERT addition ---"""
 
 def test_vader_path_unaffected():
     df = _make_df(_TEXTS, _AUTHORS)
     mock_vader = _make_vader_mock()
-    # Ensure transformers is absent so VADER is always chosen
+    """ Ensure transformers is absent so VADER is always chosen """
     with patch.dict("sys.modules", {"transformers": None}):
         with patch(_VADER_CLS, return_value=mock_vader):
             result = SentimentAnalyzer(lang="en").analyze(df)

--- a/tests/test_sentiment_analyzer.py
+++ b/tests/test_sentiment_analyzer.py
@@ -1,0 +1,503 @@
+"""
+Tests for sentiment_analyzer.py.
+
+vaderSentiment and transformers are mocked throughout so this file
+runs in complete isolation — no model downloads or heavy imports needed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from whatsapp_analyzer.sentiment_analyzer import SentimentAnalyzer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_df(messages: list[str], authors: list[str] | None = None) -> pd.DataFrame:
+    """Return a minimal cleaned DataFrame that mimics Cleaner output."""
+    n = len(messages)
+    if authors is None:
+        authors = ["Aminata"] * n
+    return pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2024-01-12 08:00"] * n),
+            "author": authors,
+            "message": messages,
+            "msg_type": ["text"] * n,
+            "group_name": ["TestGroup"] * n,
+            "cleaned_message": messages,
+            "language": ["fr"] * n,
+            "tokens": [m.split() for m in messages],
+        }
+    )
+
+
+_TEXTS = [
+    "super excellent fantastique",   # strongly positive
+    "terrible horrible mauvais",     # strongly negative
+    "bonjour au revoir",             # neutral
+    "génial bravo merveilleux",      # positive
+    "nul catastrophe désastre",      # negative
+    "cours demain annulé",           # neutral-ish
+]
+_AUTHORS = ["Aminata", "Moussa", "Aminata", "Moussa", "Aminata", "Moussa"]
+
+
+# Patch target for VADER inside the module
+_VADER_CLS = "vaderSentiment.vaderSentiment.SentimentIntensityAnalyzer"
+
+
+def _make_vader_mock(scores: list[float] | None = None):
+    """Return a mock VADER analyser that yields preset compound scores."""
+    if scores is None:
+        scores = [0.8, -0.8, 0.0, 0.6, -0.7, 0.02]
+    mock_vader = MagicMock()
+    mock_vader.polarity_scores.side_effect = [
+        {"compound": s} for s in scores
+    ]
+    return mock_vader
+
+
+# ---------------------------------------------------------------------------
+# Return type and structure
+# ---------------------------------------------------------------------------
+
+def test_analyze_returns_dict():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert isinstance(result, dict)
+
+
+def test_analyze_has_df_key():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert "df" in result
+
+
+def test_analyze_has_by_user_key():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert "by_user" in result
+
+
+def test_analyze_has_global_key():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert "global" in result
+
+
+# ---------------------------------------------------------------------------
+# Output DataFrame columns and types
+# ---------------------------------------------------------------------------
+
+def test_output_df_has_sentiment_score_column():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert "sentiment_score" in result["df"].columns
+
+
+def test_output_df_has_sentiment_label_column():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert "sentiment_label" in result["df"].columns
+
+
+def test_sentiment_score_is_float():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert result["df"]["sentiment_score"].dtype == float
+
+
+def test_sentiment_score_in_valid_range():
+    df = _make_df(_TEXTS, _AUTHORS)
+    scores = [-1.0, 0.0, 1.0, -0.5, 0.5, 0.0]
+    with patch(_VADER_CLS, return_value=_make_vader_mock(scores)):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    col = result["df"]["sentiment_score"]
+    assert col.between(-1.0, 1.0).all()
+
+
+def test_sentiment_label_values_are_valid():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert set(result["df"]["sentiment_label"]).issubset(
+        {"positive", "neutral", "negative"}
+    )
+
+
+def test_output_df_preserves_row_count():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert len(result["df"]) == len(df)
+
+
+def test_input_dataframe_not_mutated():
+    df = _make_df(_TEXTS, _AUTHORS)
+    original_cols = set(df.columns)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        SentimentAnalyzer(lang="en").analyze(df)
+    assert set(df.columns) == original_cols
+
+
+# ---------------------------------------------------------------------------
+# Label thresholds
+# ---------------------------------------------------------------------------
+
+def test_positive_label_above_threshold():
+    df = _make_df(["good"], ["Aminata"])
+    scores = [0.06]
+    with patch(_VADER_CLS, return_value=_make_vader_mock(scores)):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert result["df"]["sentiment_label"].iloc[0] == "positive"
+
+
+def test_negative_label_below_threshold():
+    df = _make_df(["bad"], ["Aminata"])
+    scores = [-0.06]
+    with patch(_VADER_CLS, return_value=_make_vader_mock(scores)):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert result["df"]["sentiment_label"].iloc[0] == "negative"
+
+
+def test_neutral_label_within_thresholds():
+    df = _make_df(["ok"], ["Aminata"])
+    scores = [0.02]
+    with patch(_VADER_CLS, return_value=_make_vader_mock(scores)):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert result["df"]["sentiment_label"].iloc[0] == "neutral"
+
+
+def test_boundary_positive_threshold_is_inclusive():
+    df = _make_df(["ok"], ["Aminata"])
+    scores = [0.06]
+    with patch(_VADER_CLS, return_value=_make_vader_mock(scores)):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert result["df"]["sentiment_label"].iloc[0] == "positive"
+
+
+def test_boundary_negative_threshold_is_inclusive():
+    df = _make_df(["bad"], ["Aminata"])
+    scores = [-0.06]
+    with patch(_VADER_CLS, return_value=_make_vader_mock(scores)):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert result["df"]["sentiment_label"].iloc[0] == "negative"
+
+
+# ---------------------------------------------------------------------------
+# by_user DataFrame
+# ---------------------------------------------------------------------------
+
+def test_by_user_is_dataframe():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert isinstance(result["by_user"], pd.DataFrame)
+
+
+def test_by_user_has_author_column():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert "author" in result["by_user"].columns
+
+
+def test_by_user_has_mean_score_column():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert "mean_score" in result["by_user"].columns
+
+
+def test_by_user_row_count_matches_unique_authors():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    n_authors = df["author"].nunique()
+    assert len(result["by_user"]) == n_authors
+
+
+# ---------------------------------------------------------------------------
+# global stats dict
+# ---------------------------------------------------------------------------
+
+def test_global_has_mean_key():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert "mean" in result["global"]
+
+
+def test_global_has_pos_pct_key():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert "pos_pct" in result["global"]
+
+
+def test_global_has_neg_pct_key():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert "neg_pct" in result["global"]
+
+
+def test_global_mean_is_float():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert isinstance(result["global"]["mean"], float)
+
+
+def test_global_pos_pct_is_float():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert isinstance(result["global"]["pos_pct"], float)
+
+
+def test_global_neg_pct_is_float():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert isinstance(result["global"]["neg_pct"], float)
+
+
+def test_global_pct_values_are_between_0_and_1():
+    df = _make_df(_TEXTS, _AUTHORS)
+    with patch(_VADER_CLS, return_value=_make_vader_mock()):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    g = result["global"]
+    assert 0.0 <= g["pos_pct"] <= 1.0
+    assert 0.0 <= g["neg_pct"] <= 1.0
+
+
+def test_global_mean_correctness():
+    df = _make_df(_TEXTS, _AUTHORS)
+    scores = [0.8, -0.8, 0.0, 0.6, -0.7, 0.02]
+    expected_mean = sum(scores) / len(scores)
+    with patch(_VADER_CLS, return_value=_make_vader_mock(scores)):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert abs(result["global"]["mean"] - expected_mean) < 1e-6
+
+
+def test_global_pos_pct_correctness():
+    df = _make_df(_TEXTS, _AUTHORS)
+    # scores > 0.05: 0.8, 0.6 => 2 out of 6
+    scores = [0.8, -0.8, 0.0, 0.6, -0.7, 0.02]
+    with patch(_VADER_CLS, return_value=_make_vader_mock(scores)):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert abs(result["global"]["pos_pct"] - 2 / 6) < 1e-6
+
+
+def test_global_neg_pct_correctness():
+    df = _make_df(_TEXTS, _AUTHORS)
+    # scores < -0.05: -0.8, -0.7 => 2 out of 6
+    scores = [0.8, -0.8, 0.0, 0.6, -0.7, 0.02]
+    with patch(_VADER_CLS, return_value=_make_vader_mock(scores)):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert abs(result["global"]["neg_pct"] - 2 / 6) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# VADER wiring
+# ---------------------------------------------------------------------------
+
+def test_vader_polarity_scores_called_for_each_message():
+    df = _make_df(_TEXTS, _AUTHORS)
+    mock_vader = _make_vader_mock()
+    with patch(_VADER_CLS, return_value=mock_vader):
+        SentimentAnalyzer(lang="en").analyze(df)
+    assert mock_vader.polarity_scores.call_count == len(_TEXTS)
+
+
+def test_vader_compound_key_is_used():
+    df = _make_df(["test message"], ["Aminata"])
+    mock_vader = MagicMock()
+    mock_vader.polarity_scores.return_value = {
+        "compound": 0.5, "pos": 0.3, "neg": 0.0, "neu": 0.7
+    }
+    with patch(_VADER_CLS, return_value=mock_vader):
+        result = SentimentAnalyzer(lang="en").analyze(df)
+    assert result["df"]["sentiment_score"].iloc[0] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+def test_empty_dataframe_raises_value_error():
+    df = pd.DataFrame(columns=["cleaned_message", "author"])
+    with pytest.raises(ValueError, match="empty"):
+        SentimentAnalyzer().analyze(df)
+
+
+def test_missing_cleaned_message_column_raises():
+    df = pd.DataFrame({"author": ["Aminata"], "message": ["test"]})
+    with pytest.raises(ValueError, match="cleaned_message"):
+        SentimentAnalyzer().analyze(df)
+
+
+def test_missing_author_column_raises():
+    df = pd.DataFrame({"cleaned_message": ["test message"], "message": ["test"]})
+    with pytest.raises(ValueError, match="author"):
+        SentimentAnalyzer().analyze(df)
+
+
+# ---------------------------------------------------------------------------
+# CamemBERT path (issue #06)
+# transformers is never imported for real — the whole module is mocked.
+# ---------------------------------------------------------------------------
+
+def _make_camembert_pipeline_mock(
+    labels_scores: list[tuple[str, float]] | None = None
+):
+    """Return a mock HuggingFace pipeline that returns preset results."""
+    if labels_scores is None:
+        labels_scores = [
+            ("LABEL_1", 0.9),
+            ("LABEL_0", 0.85),
+            ("LABEL_1", 0.55),
+            ("LABEL_1", 0.75),
+            ("LABEL_0", 0.7),
+            ("LABEL_1", 0.52),
+        ]
+    pipeline_mock = MagicMock()
+    pipeline_mock.side_effect = [
+        [{"label": label, "score": score}]
+        for label, score in labels_scores
+    ]
+    return pipeline_mock
+
+
+_TRANSFORMERS_MOCK_PATH = "whatsapp_analyzer.sentiment_analyzer.hf_pipeline"
+
+
+def _make_transformers_module_mock(pipeline_instance):
+    """Build a mock transformers module with a `pipeline` attribute."""
+    mod = MagicMock()
+    mod.pipeline = MagicMock(return_value=pipeline_instance)
+    return mod
+
+
+# --- return type and structure ---
+
+def test_camembert_analyze_returns_dict():
+    df = _make_df(_TEXTS, _AUTHORS)
+    pipe = _make_camembert_pipeline_mock()
+    with patch.dict("sys.modules", {"transformers": _make_transformers_module_mock(pipe)}):
+        result = SentimentAnalyzer(lang="fr").analyze(df)
+    assert isinstance(result, dict)
+
+
+def test_camembert_output_has_df_key():
+    df = _make_df(_TEXTS, _AUTHORS)
+    pipe = _make_camembert_pipeline_mock()
+    with patch.dict("sys.modules", {"transformers": _make_transformers_module_mock(pipe)}):
+        result = SentimentAnalyzer(lang="fr").analyze(df)
+    assert "df" in result
+
+
+def test_camembert_df_has_sentiment_score_column():
+    df = _make_df(_TEXTS, _AUTHORS)
+    pipe = _make_camembert_pipeline_mock()
+    with patch.dict("sys.modules", {"transformers": _make_transformers_module_mock(pipe)}):
+        result = SentimentAnalyzer(lang="fr").analyze(df)
+    assert "sentiment_score" in result["df"].columns
+
+
+def test_camembert_df_has_sentiment_label_column():
+    df = _make_df(_TEXTS, _AUTHORS)
+    pipe = _make_camembert_pipeline_mock()
+    with patch.dict("sys.modules", {"transformers": _make_transformers_module_mock(pipe)}):
+        result = SentimentAnalyzer(lang="fr").analyze(df)
+    assert "sentiment_label" in result["df"].columns
+
+
+def test_camembert_preserves_row_count():
+    df = _make_df(_TEXTS, _AUTHORS)
+    pipe = _make_camembert_pipeline_mock()
+    with patch.dict("sys.modules", {"transformers": _make_transformers_module_mock(pipe)}):
+        result = SentimentAnalyzer(lang="fr").analyze(df)
+    assert len(result["df"]) == len(df)
+
+
+# --- positive label maps to +score ---
+
+def test_camembert_label1_gives_positive_score():
+    df = _make_df(["super"], ["Aminata"])
+    pipe = _make_camembert_pipeline_mock([("LABEL_1", 0.9)])
+    with patch.dict("sys.modules", {"transformers": _make_transformers_module_mock(pipe)}):
+        result = SentimentAnalyzer(lang="fr").analyze(df)
+    assert result["df"]["sentiment_score"].iloc[0] == pytest.approx(0.9)
+
+
+def test_camembert_label0_gives_negative_score():
+    df = _make_df(["terrible"], ["Aminata"])
+    pipe = _make_camembert_pipeline_mock([("LABEL_0", 0.85)])
+    with patch.dict("sys.modules", {"transformers": _make_transformers_module_mock(pipe)}):
+        result = SentimentAnalyzer(lang="fr").analyze(df)
+    assert result["df"]["sentiment_score"].iloc[0] == pytest.approx(-0.85)
+
+
+def test_camembert_label_values_are_valid():
+    df = _make_df(_TEXTS, _AUTHORS)
+    pipe = _make_camembert_pipeline_mock()
+    with patch.dict("sys.modules", {"transformers": _make_transformers_module_mock(pipe)}):
+        result = SentimentAnalyzer(lang="fr").analyze(df)
+    assert set(result["df"]["sentiment_label"]).issubset(
+        {"positive", "neutral", "negative"}
+    )
+
+
+# --- fallback to VADER when transformers is absent ---
+
+def test_camembert_falls_back_to_vader_when_not_installed():
+    df = _make_df(_TEXTS, _AUTHORS)
+    mock_vader = _make_vader_mock()
+    # Remove transformers from sys.modules entirely
+    with patch.dict("sys.modules", {"transformers": None}):
+        with patch(_VADER_CLS, return_value=mock_vader):
+            result = SentimentAnalyzer(lang="fr").analyze(df)
+    assert "df" in result
+    assert mock_vader.polarity_scores.call_count == len(_TEXTS)
+
+
+# --- non-French language routes to VADER even when transformers is present ---
+
+def test_english_lang_uses_vader_not_camembert():
+    df = _make_df(_TEXTS, _AUTHORS)
+    mock_vader = _make_vader_mock()
+    pipe = _make_camembert_pipeline_mock()
+    with patch.dict("sys.modules", {"transformers": _make_transformers_module_mock(pipe)}):
+        with patch(_VADER_CLS, return_value=mock_vader):
+            SentimentAnalyzer(lang="en").analyze(df)
+    assert mock_vader.polarity_scores.call_count == len(_TEXTS)
+    assert pipe.call_count == 0
+
+
+# --- VADER path unaffected after CamemBERT addition ---
+
+def test_vader_path_unaffected():
+    df = _make_df(_TEXTS, _AUTHORS)
+    mock_vader = _make_vader_mock()
+    # Ensure transformers is absent so VADER is always chosen
+    with patch.dict("sys.modules", {"transformers": None}):
+        with patch(_VADER_CLS, return_value=mock_vader):
+            result = SentimentAnalyzer(lang="en").analyze(df)
+    assert "sentiment_score" in result["df"].columns
+    assert "sentiment_label" in result["df"].columns
+    assert "by_user" in result
+    assert "global" in result

--- a/whatsapp_analyzer/sentiment_analyzer.py
+++ b/whatsapp_analyzer/sentiment_analyzer.py
@@ -18,11 +18,11 @@ import pandas as pd
 
 logger = logging.getLogger(__name__)
 
-# Score thresholds for label assignment
+"Score thresholds for label assignment"
 _POSITIVE_THRESHOLD = 0.05
 _NEGATIVE_THRESHOLD = -0.05
 
-# CamemBERT model identifier on the HuggingFace hub
+"CamemBERT model identifier on the HuggingFace hub"
 _CAMEMBERT_MODEL = "tblard/tf-allocine"
 
 
@@ -38,9 +38,9 @@ class SentimentAnalyzer:
 
     def __init__(self, lang: str = "fr") -> None:
         self.lang = lang
-        # Lazily-loaded VADER analyser — initialised on first use
+        "Lazily-loaded VADER analyser — initialised on first use"
         self._vader: Optional[object] = None
-        # Lazily-loaded CamemBERT pipeline — initialised on first use
+        "Lazily-loaded CamemBERT pipeline — initialised on first use"
         self._camembert: Optional[object] = None
 
     def analyze(self, df: pd.DataFrame) -> dict:
@@ -173,7 +173,7 @@ class SentimentAnalyzer:
                 result = self._camembert(text)[0]
                 label: str = result["label"]
                 score: float = float(result["score"])
-                # LABEL_1 = positive, LABEL_0 = negative
+                "LABEL_1 = positive, LABEL_0 = negative"
                 scores.append(score if label == "LABEL_1" else -score)
             except Exception as exc:
                 logger.debug("CamemBERT failed on one message (%s) — using 0.0.", exc)
@@ -185,7 +185,7 @@ class SentimentAnalyzer:
     def _camembert_available() -> bool:
         """Return True when the transformers package can be imported."""
         try:
-            import transformers  # noqa: F401
+            import transformers
             return True
         except ImportError:
             return False

--- a/whatsapp_analyzer/sentiment_analyzer.py
+++ b/whatsapp_analyzer/sentiment_analyzer.py
@@ -1,0 +1,200 @@
+"""
+Sentiment analysis module for WhatsApp conversation analysis.
+
+Supports two backends selected automatically based on language and availability:
+  - VADER  — always available, language-agnostic fallback.
+  - CamemBERT — optional HuggingFace model for French text (issue #06).
+
+Input:  DataFrame produced by Cleaner  (columns include: cleaned_message, author)
+Output: dict with keys 'df', 'by_user', 'global'
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# Score thresholds for label assignment
+_POSITIVE_THRESHOLD = 0.05
+_NEGATIVE_THRESHOLD = -0.05
+
+# CamemBERT model identifier on the HuggingFace hub
+_CAMEMBERT_MODEL = "tblard/tf-allocine"
+
+
+class SentimentAnalyzer:
+    """
+    Score the sentiment of each cleaned message.
+
+    Args:
+        lang: Language code ('fr', 'en', ...).
+              When lang == 'fr' and transformers is installed, CamemBERT
+              is used instead of VADER for higher accuracy on French text.
+    """
+
+    def __init__(self, lang: str = "fr") -> None:
+        self.lang = lang
+        # Lazily-loaded VADER analyser — initialised on first use
+        self._vader: Optional[object] = None
+        # Lazily-loaded CamemBERT pipeline — initialised on first use
+        self._camembert: Optional[object] = None
+
+    def analyze(self, df: pd.DataFrame) -> dict:
+        """
+        Score the sentiment of every message in the DataFrame.
+
+        Args:
+            df: Output of Cleaner.clean(), must contain 'cleaned_message'
+                and 'author' columns.
+
+        Returns:
+            Dict with keys:
+              - 'df'       — enriched DataFrame with 'sentiment_score' (float,
+                             range -1 to 1) and 'sentiment_label' (str).
+              - 'by_user'  — DataFrame: mean sentiment score per author.
+              - 'global'   — dict: mean (float), pos_pct (float), neg_pct (float).
+
+        Raises:
+            ValueError: If df is empty or required columns are missing.
+        """
+        if df.empty:
+            raise ValueError("Input DataFrame is empty.")
+        for col in ("cleaned_message", "author"):
+            if col not in df.columns:
+                raise ValueError(
+                    f"DataFrame must contain a '{col}' column."
+                )
+
+        texts = df["cleaned_message"].fillna("").tolist()
+
+        if self.lang == "fr" and self._camembert_available():
+            logger.info("Using CamemBERT for French sentiment analysis.")
+            scores = self._score_camembert(texts)
+        else:
+            logger.info("Using VADER for sentiment analysis (lang=%s).", self.lang)
+            scores = self._score_vader(texts)
+
+        labels = [self._label(s) for s in scores]
+
+        result_df = df.copy()
+        result_df["sentiment_score"] = scores
+        result_df["sentiment_label"] = labels
+
+        by_user = (
+            result_df.groupby("author")["sentiment_score"]
+            .mean()
+            .reset_index()
+            .rename(columns={"sentiment_score": "mean_score"})
+        )
+
+        total = len(labels)
+        pos_count = labels.count("positive")
+        neg_count = labels.count("negative")
+        global_stats = {
+            "mean": float(result_df["sentiment_score"].mean()),
+            "pos_pct": float(pos_count / total) if total else 0.0,
+            "neg_pct": float(neg_count / total) if total else 0.0,
+        }
+
+        logger.info(
+            "Sentiment analysis complete — mean=%.3f, pos=%.1f%%, neg=%.1f%%.",
+            global_stats["mean"],
+            global_stats["pos_pct"] * 100,
+            global_stats["neg_pct"] * 100,
+        )
+
+        return {"df": result_df, "by_user": by_user, "global": global_stats}
+
+    def _score_vader(self, texts: list[str]) -> list[float]:
+        """
+        Score each text with VADER's compound score (-1 to 1).
+
+        The VADER analyser is instantiated once and reused across calls.
+        """
+        from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+        if self._vader is None:
+            self._vader = SentimentIntensityAnalyzer()
+
+        return [
+            float(self._vader.polarity_scores(text)["compound"])
+            for text in texts
+        ]
+
+    def _score_camembert(self, texts: list[str]) -> list[float]:
+        """
+        Score each text using the CamemBERT-based French sentiment pipeline.
+
+        Falls back to VADER with a log warning if transformers is unavailable
+        or if loading the model fails for any reason.
+
+        The pipeline maps HuggingFace labels to the [-1, 1] range:
+          - LABEL_1 (positive) → raw probability kept as-is  (+score)
+          - LABEL_0 (negative) → negated raw probability     (-score)
+
+        Args:
+            texts: List of cleaned message strings.
+
+        Returns:
+            List of float scores in [-1, 1].
+        """
+        try:
+            from transformers import pipeline as hf_pipeline
+        except ImportError:
+            logger.warning(
+                "transformers is not installed — falling back to VADER. "
+                "Run: pip install transformers torch"
+            )
+            return self._score_vader(texts)
+
+        if self._camembert is None:
+            try:
+                self._camembert = hf_pipeline(
+                    "text-classification",
+                    model=_CAMEMBERT_MODEL,
+                    tokenizer=_CAMEMBERT_MODEL,
+                    truncation=True,
+                    max_length=512,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Could not load CamemBERT model (%s) — falling back to VADER.",
+                    exc,
+                )
+                return self._score_vader(texts)
+
+        scores: list[float] = []
+        for text in texts:
+            try:
+                result = self._camembert(text)[0]
+                label: str = result["label"]
+                score: float = float(result["score"])
+                # LABEL_1 = positive, LABEL_0 = negative
+                scores.append(score if label == "LABEL_1" else -score)
+            except Exception as exc:
+                logger.debug("CamemBERT failed on one message (%s) — using 0.0.", exc)
+                scores.append(0.0)
+
+        return scores
+
+    @staticmethod
+    def _camembert_available() -> bool:
+        """Return True when the transformers package can be imported."""
+        try:
+            import transformers  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+    @staticmethod
+    def _label(score: float) -> str:
+        """Map a compound score to a human-readable sentiment label."""
+        if score > _POSITIVE_THRESHOLD:
+            return "positive"
+        if score < _NEGATIVE_THRESHOLD:
+            return "negative"
+        return "neutral"


### PR DESCRIPTION
## Summary

<!-- One sentence describing what this PR does. -->

Closes #<!-- issue number -->

## Changes

<!-- List the files modified or created. -->

-
-

## Checklist

### Code quality
- [ ] All code and comments are in **English**
- [ ] No decorative comment separators (`#---`, `#===`, etc.) — single `#` only
- [ ] Type hints on every public function signature
- [ ] Docstrings on every public class and non-trivial function
- [ ] No `print()` statements — `logging.getLogger(__name__)` used instead
- [ ] No dead code, no commented-out blocks

### Tests
- [ ] Test file written for this module: `tests/test_<module>.py`
- [ ] All external dependencies mocked — no real NLP models called in tests
- [ ] Module runs in **isolation**: `python -m pytest tests/test_<module>.py`
- [ ] Full suite still passes: `python -m pytest`

### Dependencies
- [ ] No circular imports introduced (see dependency table in `CONTRIBUTING.md`)
- [ ] Heavy external imports are **lazy** (inside method bodies, not at module level)

### Data & privacy
- [ ] No real WhatsApp exports committed (`data/` is in `.gitignore`)
- [ ] No real phone numbers or full names in test fixtures or docs

### Branch & commit
- [ ] Branch named `feature/<issue-number>-short-description`
- [ ] Commits follow the format: `feat|fix|test|docs|refactor(<scope>): message`
- [ ] PR targets `main` and is up to date with it
